### PR TITLE
Adding service that allows setting of position with an position confidence indicator.

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,13 +153,28 @@ To prevent that, make sure you **don't use** [cover groups](https://www.home-ass
         position: 30
 ```
 
-### Service to set known position
+### Service to set known position without triggering cover movement.
 
-This service lets you specify the position of the cover if you have other sources of information, i.e. sensors.
+This component provides a service that lets you specify the position of the cover if you have other sources of information, i.e. sensors.
+
+```
+  name. cover_rf_time_based.set_known_position:
+  description: Set position aquired outside of this component without triggering action
+  fields:
+    entity_id:
+      description: entity id of cover to set position for
+      example: cover.garage_door
+    position:
+      description: position of cover, between 0 and 100
+      example: 50
+    confident: (optional)
+      description: if we are confident in this position, i.e. affects if state is assumed or not
+      example: True
+```
 
 It's useful as the cover may have changed position outside of HA's knowledge, and also to allow a confirmed position to make the arrow buttons display more appropriately.
 
-To this end the position in the service also has an optional parameter of 'confident' that affects how the cover is presented in HA.  Setting confident to ```true``` will mean that certain button operations aren't permitted.
+To this end the position in the service has an optional parameter of 'confident' that affects how the cover is presented in HA.  Setting confident to ```true``` will mean that certain button operations aren't permitted.
 
 e.g. This example automation shows a reed sensor that indicate a garage door is closed when contact is made:
 

--- a/README.md
+++ b/README.md
@@ -152,3 +152,35 @@ To prevent that, make sure you **don't use** [cover groups](https://www.home-ass
         entity_id: cover.room_4
         position: 30
 ```
+
+### Service to set known position
+
+This service lets you specify the position of the cover if you have other sources of information, i.e. sensors.
+
+It's useful as the cover may have changed position outside of HA's knowledge, and also to allow a confirmed position to make the arrow buttons display more appropriately.
+
+To this end the position in the service also has an optional parameter of 'confident' that affects how the cover is presented in HA.  Setting confident to ```true``` will mean that certain button operations aren't permitted.
+
+e.g. This example automation shows a reed sensor that indicate a garage door is closed when contact is made:
+
+```
+- id: 'garage_closed'
+  alias: 'Doors: garage set closed when contact'
+  description: ''
+  trigger:
+  - entity_id: binary_sensor.door_garage_cover
+    platform: state
+    to: 'off'
+  condition: []
+  action:
+  - data:
+      confident: true
+      entity_id: cover.garage_door
+      position: 0
+    service: cover_rf_time_based.set_known_position
+``` 
+
+As we have set confident to true down arrow is now no longer available in default  HA frontend when the cover is closed.
+If we ommitted the confident parameter all arrows would be available.
+
+The 'known state' (in this instance of being closed) is persisted until we trigger an action, as soon as position is based on timer logic we revert back to an assumed state, where all buttons are available.

--- a/custom_components/cover_rf_time_based/cover.py
+++ b/custom_components/cover_rf_time_based/cover.py
@@ -185,8 +185,11 @@ class CoverTimeBased(CoverEntity, RestoreEntity):
         return self._assume_uncertain_position
  
     async def async_set_cover_position(self, **kwargs):
-        """Move the cover to a specific position."""
-        await self.set_position(position)
+       """Move the cover to a specific position."""
+       if ATTR_POSITION in kwargs:
+           position = kwargs[ATTR_POSITION]
+           _LOGGER.debug(self._name + ': ' + 'async_set_cover_position: %d', position)
+           await self.set_position(position)
 
     async def async_close_cover(self, **kwargs):
         """Turn the device close."""

--- a/custom_components/cover_rf_time_based/cover.py
+++ b/custom_components/cover_rf_time_based/cover.py
@@ -6,6 +6,7 @@ import voluptuous as vol
 from datetime import timedelta
 
 from homeassistant.core import callback
+from homeassistant.helpers import entity_platform
 from homeassistant.helpers.event import async_track_utc_time_change, async_track_time_interval
 from homeassistant.components.cover import (
     ATTR_CURRENT_POSITION,
@@ -15,6 +16,7 @@ from homeassistant.components.cover import (
 )
 from homeassistant.const import (
     CONF_NAME,
+    ATTR_ENTITY_ID,
     SERVICE_CLOSE_COVER,
     SERVICE_OPEN_COVER,
     SERVICE_STOP_COVER,
@@ -37,6 +39,9 @@ DEFAULT_SEND_STOP_AT_ENDS = False
 CONF_OPEN_SCRIPT_ENTITY_ID = 'open_script_entity_id'
 CONF_CLOSE_SCRIPT_ENTITY_ID = 'close_script_entity_id'
 CONF_STOP_SCRIPT_ENTITY_ID = 'stop_script_entity_id'
+ATTR_CONFIDENT = 'confident'
+ATTR_POSITION = 'position'
+SERVICE_SET_KNOWN_POSITION = 'set_known_position'
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
     {
@@ -57,6 +62,16 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
     }
 )
 
+POSITION_SCHEMA = vol.Schema(
+    {
+        vol.Required(ATTR_ENTITY_ID): cv.entity_id,
+        vol.Required(ATTR_POSITION): cv.positive_int,
+        vol.Optional(ATTR_CONFIDENT, default=False): cv.boolean
+    }
+)
+
+DOMAIN = "cover_rf_time_based"
+
 def devices_from_config(domain_config):
     """Parse configuration and add cover devices."""
     devices = []
@@ -72,27 +87,36 @@ def devices_from_config(domain_config):
         devices.append(device)
     return devices
 
+
+
 async def async_setup_platform(hass, config, async_add_entities, discovery_info=None):
     """Set up the cover platform."""
     async_add_entities(devices_from_config(config))
 
+    platform = entity_platform.current_platform.get()
+
+    platform.async_register_entity_service(
+        SERVICE_SET_KNOWN_POSITION, POSITION_SCHEMA, "set_known_position"
+    )
+
+
 class CoverTimeBased(CoverEntity, RestoreEntity):
-	
     def __init__(self, device_id, name, travel_time_down, travel_time_up, open_script_entity_id, close_script_entity_id, stop_script_entity_id, send_stop_at_ends):
         """Initialize the cover."""
         from xknx.devices import TravelCalculator
         self._travel_time_down = travel_time_down
         self._travel_time_up = travel_time_up
         self._open_script_entity_id = open_script_entity_id
-        self._close_script_entity_id = close_script_entity_id        
-        self._stop_script_entity_id = stop_script_entity_id        
-        self._send_stop_at_ends = send_stop_at_ends        
+        self._close_script_entity_id = close_script_entity_id 
+        self._stop_script_entity_id = stop_script_entity_id
+        self._send_stop_at_ends = send_stop_at_ends
+        self._confident_in_known_position = False
 
         if name:
             self._name = name
         else:
             self._name = device_id
-		
+
         self._unsubscribe_auto_updater = None
 
         self.tc = TravelCalculator(self._travel_time_down, self._travel_time_up)
@@ -157,15 +181,12 @@ class CoverTimeBased(CoverEntity, RestoreEntity):
 
     @property
     def assumed_state(self):
-        """Return True because covers can be stopped midway."""
-        return True
-
+        """Return False unless we have set position externally through send_know_position service."""
+        return self._confident_in_known_position
+ 
     async def async_set_cover_position(self, **kwargs):
         """Move the cover to a specific position."""
-        if ATTR_POSITION in kwargs:
-            position = kwargs[ATTR_POSITION]
-            _LOGGER.debug(self._name + ': ' + 'async_set_cover_position: %d', position)
-            await self.set_position(position)
+        await self.set_position(position)
 
     async def async_close_cover(self, **kwargs):
         """Turn the device close."""
@@ -205,6 +226,7 @@ class CoverTimeBased(CoverEntity, RestoreEntity):
             self.tc.start_travel(position)
             _LOGGER.debug(self._name + ': ' + 'set_position :: command %s', command)
             await self._async_handle_command(command)
+
         return
 
     def start_auto_updater(self):
@@ -237,6 +259,13 @@ class CoverTimeBased(CoverEntity, RestoreEntity):
         """Return if cover has reached its final position."""
         return self.tc.position_reached()
 
+    async def set_known_position(self, **kwargs):
+        position = kwargs[ATTR_POSITION]
+        confident = kwargs[ATTR_CONFIDENT] if ATTR_CONFIDENT in kwargs else False
+        _LOGGER.debug(self._name: + ': ' + 'set_known_position :: position received %d', position)
+        self._confident_in_known_position = confident 
+        self.tc.set_position(position)
+
     async def auto_stop_if_necessary(self):
         """Do auto stop if necessary."""
         current_position = self.tc.current_position()
@@ -252,6 +281,8 @@ class CoverTimeBased(CoverEntity, RestoreEntity):
     
     
     async def _async_handle_command(self, command, *args):
+        """As soon as we trigger an action we are unconfirmed, wait for sensor confirmation for assumed state"""
+        self._confident_in_known_position = False
         if command == "close_cover":
             cmd = "DOWN"
             self._state = False

--- a/custom_components/cover_rf_time_based/cover.py
+++ b/custom_components/cover_rf_time_based/cover.py
@@ -64,7 +64,7 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
 
 POSITION_SCHEMA = vol.Schema(
     {
-        vol.Required(ATTR_ENTITY_ID): cv.entity_id,
+        vol.Required(ATTR_ENTITY_ID): cv.entity_ids,
         vol.Required(ATTR_POSITION): cv.positive_int,
         vol.Optional(ATTR_CONFIDENT, default=False): cv.boolean
     }

--- a/custom_components/cover_rf_time_based/cover.py
+++ b/custom_components/cover_rf_time_based/cover.py
@@ -110,7 +110,7 @@ class CoverTimeBased(CoverEntity, RestoreEntity):
         self._close_script_entity_id = close_script_entity_id 
         self._stop_script_entity_id = stop_script_entity_id
         self._send_stop_at_ends = send_stop_at_ends
-        self._confident_in_known_position = False
+        self._assume_uncertain_position = True 
 
         if name:
             self._name = name
@@ -181,8 +181,8 @@ class CoverTimeBased(CoverEntity, RestoreEntity):
 
     @property
     def assumed_state(self):
-        """Return False unless we have set position externally through send_know_position service."""
-        return self._confident_in_known_position
+        """Return True unless we have set position with confidence through send_know_position service."""
+        return self._assume_uncertain_position
  
     async def async_set_cover_position(self, **kwargs):
         """Move the cover to a specific position."""
@@ -263,7 +263,7 @@ class CoverTimeBased(CoverEntity, RestoreEntity):
         position = kwargs[ATTR_POSITION]
         confident = kwargs[ATTR_CONFIDENT] if ATTR_CONFIDENT in kwargs else False
         _LOGGER.debug(self._name + ': ' + 'set_known_position :: position received %d', position)
-        self._confident_in_known_position = confident 
+        self._assume_uncertain_position = not confident 
         self.tc.set_position(position)
 
     async def auto_stop_if_necessary(self):
@@ -282,7 +282,7 @@ class CoverTimeBased(CoverEntity, RestoreEntity):
     
     async def _async_handle_command(self, command, *args):
         """As soon as we trigger an action we are unconfirmed, wait for sensor confirmation for assumed state"""
-        self._confident_in_known_position = False
+        self._assume_uncertain_position = True
         if command == "close_cover":
             cmd = "DOWN"
             self._state = False

--- a/custom_components/cover_rf_time_based/cover.py
+++ b/custom_components/cover_rf_time_based/cover.py
@@ -262,7 +262,7 @@ class CoverTimeBased(CoverEntity, RestoreEntity):
     async def set_known_position(self, **kwargs):
         position = kwargs[ATTR_POSITION]
         confident = kwargs[ATTR_CONFIDENT] if ATTR_CONFIDENT in kwargs else False
-        _LOGGER.debug(self._name: + ': ' + 'set_known_position :: position received %d', position)
+        _LOGGER.debug(self._name + ': ' + 'set_known_position :: position received %d', position)
         self._confident_in_known_position = confident 
         self.tc.set_position(position)
 

--- a/custom_components/cover_rf_time_based/services.yaml
+++ b/custom_components/cover_rf_time_based/services.yaml
@@ -4,3 +4,15 @@ send_command:
   fields:
     command: {description: The command to be sent., example: 'open_cover'}
     device_id: {description: device ID.}
+set_known_position:
+  description: Set position aquired outside of this component without triggering action
+  fields:
+    entity_id:
+      description: entity id of cover to set position for
+      example: cover.garage_door
+    position:
+      description: position of cover, between 0 and 100
+      example: 50
+    confident:
+      description: if we are confident in this position, i.e. affects if state is assumed or not
+      example: True


### PR DESCRIPTION
This is useful for when sensors can detect the real cover position, which may have been altered outside of HA Control.

Example use case:
  Door sensor gets activated when cover is fully closed, this triggers the service call setting the cover position to 0.

The service takes:

  -- entity_id
  -- position
  -- confident - a boolean which indicates that we know the given position confidentally, which alters assumed_state to False.

The internally maintained state of confidence we have in our poistion is reset to false whenever the component triggers an action.