### PR TITLE
Adding position_target parameter to set_known_position service

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ Of course you can customize based on what ever other way to trigger these 3 type
 
 This component provides the ```cover_rf_time_based.set_known_position``` service that lets you specify the position of the cover if you have other sources of information, i.e. sensors. It's useful as the cover may have changed position outside of HA's knowledge, and also to allow a confirmed position to make the arrow buttons display more appropriately.
 
-To this end the position in the service has an optional parameter of 'confident' that affects how the cover is presented in HA. Setting confident to ```true``` will mean that certain button operations aren't permitted.
+To this end the position in the service has an optional parameter of ```confident``` that affects how the cover is presented in HA. Setting confident to ```true``` will mean that certain button operations aren't permitted.
 
 Another optional parameter of ```position_type``` allows the setting of either the ```target``` or ```current``` posistion.
 
@@ -167,7 +167,7 @@ We have set ```confident``` to ```true``` as the sensor has confirmed a final po
 ```
 
 ```confident``` is omitted so defaulted to ```false``` as we're not sure where the movement may end, so all arrows are available.
-```position_type``` is omitted so defaulted```target```, meaning cover will transition to ```position``` without triggering any start or stop actions.
+```position_type``` is omitted so defaulted to ```target```, meaning cover will transition to ```position``` without triggering any start or stop actions.
 
 
 ### Icon customization

--- a/README.md
+++ b/README.md
@@ -112,13 +112,14 @@ Of course you can customize based on what ever other way to trigger these 3 type
 
 ### Service to set or move to position without triggering cover movement.
 
-This component provides the ```cover_rf_time_based.set_known_position`` service that lets you specify the position of the cover if you have other sources of information, i.e. sensors. It's useful as the cover may have changed position outside of HA's knowledge, and also to allow a confirmed position to make the arrow buttons display more appropriately.
+This component provides the ```cover_rf_time_based.set_known_position``` service that lets you specify the position of the cover if you have other sources of information, i.e. sensors. It's useful as the cover may have changed position outside of HA's knowledge, and also to allow a confirmed position to make the arrow buttons display more appropriately.
 
 To this end the position in the service has an optional parameter of 'confident' that affects how the cover is presented in HA. Setting confident to ```true``` will mean that certain button operations aren't permitted.
-Another optional parameter of ```position_type``` allows the setting of either the target or current posistion, following examples explain usage:
+
+Another optional parameter of ```position_type``` allows the setting of either the ```target``` or ```current``` posistion.
 
 
-Following examples to help explaing parametes:
+Following examples to help explain parameters and use cases:
 
 1.  This example automation uses ```position_type: current``` and ```confident: true``` when a reed sensor has indicated a garage door is closed when contact is made:
 
@@ -140,14 +141,14 @@ Following examples to help explaing parametes:
     service: cover_rf_time_based.set_known_position
 ``` 
 
-We have set ```confident``` to ```true`` as the sensor has confirmed a final position. The down arrow is now no longer available in default  HA frontend when the cover is closed. 
+We have set ```confident``` to ```true``` as the sensor has confirmed a final position. The down arrow is now no longer available in default  HA frontend when the cover is closed. 
 ```position_type``` of ```current``` means the current position is moved immediately to 0 and stops there (provided cover is not moving, otherwise will contiune moving to original target). 
 
 
 2.  This example uses ```position_type: target``` (the default) and ```confident: false``` (also default) where an RF bridge has interecepted an RF command, so we know an external remote has triggered cover opening action:
 
 ```yaml
-- id: 'garage_opening'
+- id: 'rf_cover_opening'
   alias: 'RF_Cover: set opening when rf received'
   description: ''
   trigger:

--- a/README.md
+++ b/README.md
@@ -225,7 +225,7 @@ As we have set confident to true as the sensor has confirmed a final position. T
 ```
 
 ```confident``` is omitted so defaulted to ```false``` as we're not sure where the movement may end, so all arrows are available.
-```position_type``` is omitted so defaulted```target``, meaning cover will transition to ```position``` without triggering any start or stop actions.
+```position_type``` is omitted so defaulted```target```, meaning cover will transition to ```position``` without triggering any start or stop actions.
 
 
 

--- a/custom_components/cover_rf_time_based/services.yaml
+++ b/custom_components/cover_rf_time_based/services.yaml
@@ -14,5 +14,9 @@ set_known_position:
       description: position of cover, between 0 and 100
       example: 50
     confident:
-      description: if we are confident in this position, i.e. affects if state is assumed or not
+      description: optional (default is false) - if we are confident in this position, i.e. affects if state is assumed or not
       example: True
+    position_type:
+      description: optional (default is target)- specifies if the position we are passing in is the target or the current position. Defaults to target meaning we will transition slider from current posution to given target. Specifiying current will set current position.
+      example: current
+


### PR DESCRIPTION
This implements your idea of allowing a target position to be triggered from the service, with the slider transitioning to the new position.

I've made this the default as I can see it being more useful than previous approach.  Old functionality of setting current position needs to be specified with the `position_type: current parameter`.

With both postion_types we can now get the cover state into HA when it is externally triggered to move or returned to a 'home' position (either open or close).