### PR TITLE
Add known action service

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ The example below assumes you've set `send_stop_at_ends: True` in the cover conf
 Of course you can customize based on what ever other way to trigger these 3 type of movements. You could, for example, turn on and off warning lights along with the movement.
 
 
-### Services to set position or actionwithout triggering cover movement.
+### Services to set position or action without triggering cover movement.
 
 This component provides 2 services:
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ With this component you can add a time-based cover. You have to set triggering s
 
 You can adapt it to your requirements, actually any cover system could be used which uses 3 triggers: up, stop, down. The idea is to embed your triggers into scripts which can be hooked into this component via config. For example, you can use RF-bridge or dual-gang switch running Tasmota firmware integrated like in the examples shown below.
 
-The component adds two services ```set_known_position``` and ```set_known_action`` which allow updating HA in response to external stimuli like sensors. 
+The component adds two services ```set_known_position``` and ```set_known_action``` which allow updating HA in response to external stimuli like sensors. 
 
 [Support forum](https://community.home-assistant.io/t/custom-component-cover-time-based/187654/3?u=robi)
 
@@ -116,15 +116,15 @@ Of course you can customize based on what ever other way to trigger these 3 type
 
 This component provides 2 services:
 
-  --  ```cover_rf_time_based.set_known_position``` lets you specify the position of the cover if you have other sources of information, i.e. sensors. It's useful as the cover may have changed position outside of HA's knowledge, and also to allow a confirmed position to make the arrow buttons display more appropriately.
-  --  ```cover_rf_time_based.set_known_action``` is for instances when an action is caught in the real world but not process in HA, .e.g. an RF bridge detects a ```stop``` action that we want to input into HA without calling the stop command.
+1.  ```cover_rf_time_based.set_known_position``` lets you specify the position of the cover if you have other sources of information, i.e. sensors. It's useful as the cover may have changed position outside of HA's knowledge, and also to allow a confirmed position to make the arrow buttons display more appropriately.
+1.  ```cover_rf_time_based.set_known_action``` is for instances when an action is caught in the real world but not process in HA, .e.g. an RF bridge detects a ```stop``` action that we want to input into HA without calling the stop command.
 
 
 #### ```cover_rf_time_based.set_known_position```
 
 In addition to ```entity_id``` and ```position``` takes 2 optional parameters:
-  -- ```confident``` that affects how the cover is presented in HA. Setting confident to ```true``` will mean that certain button operations aren't permitted.
-  -- ```position_type``` allows the setting of either the ```target``` or ```current``` posistion.
+* ```confident``` that affects how the cover is presented in HA. Setting confident to ```true``` will mean that certain button operations aren't permitted.
+* ```position_type``` allows the setting of either the ```target``` or ```current``` posistion.
 
 Following examples to help explain parameters and use cases:
 

--- a/custom_components/cover_rf_time_based/cover.py
+++ b/custom_components/cover_rf_time_based/cover.py
@@ -151,7 +151,12 @@ class CoverTimeBased(CoverEntity, RestoreEntity):
         if (old_state is not None and self.tc is not None and old_state.attributes.get(ATTR_CURRENT_POSITION) is not None):
             self.tc.set_position(int(old_state.attributes.get(ATTR_CURRENT_POSITION)))
         if (old_state is not None and old_state.attributes.get(ATTR_UNCONFIRMED_STATE) is not None):
-            self._assume_uncertain_position =  old_state.attributes.get(ATTR_UNCONFIRMED_STATE).lower in ["yes", "true", "1"]
+         if type(old_state.attributes.get(ATTR_UNCONFIRMED_STATE)) == bool:
+           self._assume_uncertain_position = old_state.attributes.get(ATTR_UNCONFIRMED_STATE)
+         elif type(old_state.attributes.get(ATTR_UNCONFIRMED_STATE)) is str:
+           self._assume_uncertain_position = old_state.attributes.get(ATTR_UNCONFIRMED_STATE).lower in ["yes", "true", "1"]
+         else:
+           _LOGGER.debug(self._name + ': ' + 'async_added_to_hass :: ATTR_UNCONFIRMED_STATE type %s', str(type(old_state.attributes.get(ATTR_UNCONFIRMED_STATE))))
 
     def _handle_my_button(self):
         """Handle the MY button press"""
@@ -163,7 +168,7 @@ class CoverTimeBased(CoverEntity, RestoreEntity):
     @property
     def unconfirmed_state(self):
         """Return the assume state as a string to persist through restarts ."""
-        return str(self.assumed_state)
+        return str(self._assume_uncertain_position)
 
     @property
     def name(self):
@@ -178,7 +183,7 @@ class CoverTimeBased(CoverEntity, RestoreEntity):
             attr[CONF_TRAVELLING_TIME_DOWN] = self._travel_time_down
         if self._travel_time_up is not None:
             attr[CONF_TRAVELLING_TIME_UP] = self._travel_time_up 
-        attr[ATTR_UNCONFIRMED_STATE] = self._assume_uncertain_position 
+        attr[ATTR_UNCONFIRMED_STATE] = str(self._assume_uncertain_position)
         return attr
 
     @property

--- a/custom_components/cover_rf_time_based/cover.py
+++ b/custom_components/cover_rf_time_based/cover.py
@@ -133,7 +133,6 @@ class CoverTimeBased(CoverEntity, RestoreEntity):
         self._assume_uncertain_position = True 
         self._target_position = 0
         self._processing_known_position = False
-        self._processing_known_action = False
 
         if name:
             self._name = name
@@ -225,8 +224,7 @@ class CoverTimeBased(CoverEntity, RestoreEntity):
         self._target_position = 0
 
         self.start_auto_updater()
-        if not self._processing_known_action:
-          await self._async_handle_command(SERVICE_CLOSE_COVER)
+        await self._async_handle_command(SERVICE_CLOSE_COVER)
 
     async def async_open_cover(self, **kwargs):
         """Turn the device open."""
@@ -235,15 +233,13 @@ class CoverTimeBased(CoverEntity, RestoreEntity):
         self._target_position = 100
 
         self.start_auto_updater()
-        if not self._processing_known_action:
-          await self._async_handle_command(SERVICE_OPEN_COVER)
+        await self._async_handle_command(SERVICE_OPEN_COVER)
 
     async def async_stop_cover(self, **kwargs):
         """Turn the device stop."""
         _LOGGER.debug(self._name + ': ' + 'async_stop_cover')
         self._handle_my_button()
-        if not self._processing_known_action:
-          await self._async_handle_command(SERVICE_STOP_COVER)
+        await self._async_handle_command(SERVICE_STOP_COVER)
 
     async def set_position(self, position):
         _LOGGER.debug(self._name + ': ' + 'set_position')

--- a/custom_components/cover_rf_time_based/manifest.json
+++ b/custom_components/cover_rf_time_based/manifest.json
@@ -5,5 +5,5 @@
   "requirements": [
     "xknx==0.9.4"
   ],
-  "codeowners": ["@davidramosweb", "@nagyrobi"]
+  "codeowners": ["@davidramosweb", "@nagyrobi", "@Alfiegerner"]
 }

--- a/custom_components/cover_rf_time_based/services.yaml
+++ b/custom_components/cover_rf_time_based/services.yaml
@@ -19,4 +19,13 @@ set_known_position:
     position_type:
       description: optional (default is target)- specifies if the position we are passing in is the target or the current position. Defaults to target meaning we will transition slider from current posution to given target. Specifiying current will set current position.
       example: current
+set_known_action:
+  description: Action of open, stop or close captured outside of HA, trigger cover response in HA without triggering action
+  fields:
+    entity_id:
+      description: entity id of cover to set position for
+      example: cover.garage_door
+    action:
+      description: must be one of open, close or stop
+      example: open
 


### PR DESCRIPTION
This is to address the use case for when an action such as stop is detected outside of HA and we want to trigger UI and cover state.