### PR TITLE
passing variables unique_id and command to the script

### DIFF
--- a/custom_components/cover_rf_time_based/cover.py
+++ b/custom_components/cover_rf_time_based/cover.py
@@ -437,7 +437,7 @@ class CoverTimeBased(CoverEntity, RestoreEntity):
             if self._cover_entity_id is not None:
                 await self.hass.services.async_call("cover", "close_cover", {"entity_id": self._cover_entity_id}, False)
             else:
-                await self.hass.services.async_call("homeassistant", "turn_on", {"entity_id": self._close_script_entity_id, "variables": {"source": self._unique_id, "command": "close"}}, False)
+                await self.hass.services.async_call("homeassistant", "turn_on", {"entity_id": self._close_script_entity_id, "variables": {"source": self._name, "command": "close"}}, False)
 
         elif command == "open_cover":
             cmd = "UP"
@@ -445,7 +445,7 @@ class CoverTimeBased(CoverEntity, RestoreEntity):
             if self._cover_entity_id is not None:
                 await self.hass.services.async_call("cover", "open_cover", {"entity_id": self._cover_entity_id}, False)
             else:
-                await self.hass.services.async_call("script", "turn_on", {"entity_id": self._open_script_entity_id, "variables": {"source": self._unique_id, "command": "open"}}, False)
+                await self.hass.services.async_call("script", "turn_on", {"entity_id": self._open_script_entity_id, "variables": {"source": self._name, "command": "open"}}, False)
 
         elif command == "stop_cover":
             cmd = "STOP"
@@ -453,7 +453,7 @@ class CoverTimeBased(CoverEntity, RestoreEntity):
             if self._cover_entity_id is not None:
                 await self.hass.services.async_call("cover", "stop_cover", {"entity_id": self._cover_entity_id}, False)
             else:
-                await self.hass.services.async_call("homeassistant", "turn_on", {"entity_id": self._stop_script_entity_id, "variables": {"source": self._unique_id, "command": "stop"}}, False)
+                await self.hass.services.async_call("homeassistant", "turn_on", {"entity_id": self._stop_script_entity_id, "variables": {"source": self._name, "command": "stop"}}, False)
 
         _LOGGER.debug(self._name + ': ' + '_async_handle_command :: %s', cmd)
 

--- a/custom_components/cover_rf_time_based/cover.py
+++ b/custom_components/cover_rf_time_based/cover.py
@@ -437,7 +437,7 @@ class CoverTimeBased(CoverEntity, RestoreEntity):
             if self._cover_entity_id is not None:
                 await self.hass.services.async_call("cover", "close_cover", {"entity_id": self._cover_entity_id}, False)
             else:
-                await self.hass.services.async_call("homeassistant", "turn_on", {"entity_id": self._close_script_entity_id}, False)
+                await self.hass.services.async_call("homeassistant", "turn_on", {"entity_id": self._close_script_entity_id, "variables": {"source": self._unique_id, "command": "close"}}, False)
 
         elif command == "open_cover":
             cmd = "UP"
@@ -445,7 +445,7 @@ class CoverTimeBased(CoverEntity, RestoreEntity):
             if self._cover_entity_id is not None:
                 await self.hass.services.async_call("cover", "open_cover", {"entity_id": self._cover_entity_id}, False)
             else:
-                await self.hass.services.async_call("homeassistant", "turn_on", {"entity_id": self._open_script_entity_id}, False)
+                await self.hass.services.async_call("script", "turn_on", {"entity_id": self._open_script_entity_id, "variables": {"source": self._unique_id, "command": "open"}}, False)
 
         elif command == "stop_cover":
             cmd = "STOP"
@@ -453,7 +453,7 @@ class CoverTimeBased(CoverEntity, RestoreEntity):
             if self._cover_entity_id is not None:
                 await self.hass.services.async_call("cover", "stop_cover", {"entity_id": self._cover_entity_id}, False)
             else:
-                await self.hass.services.async_call("homeassistant", "turn_on", {"entity_id": self._stop_script_entity_id}, False)
+                await self.hass.services.async_call("homeassistant", "turn_on", {"entity_id": self._stop_script_entity_id, "variables": {"source": self._unique_id, "command": "stop"}}, False)
 
         _LOGGER.debug(self._name + ': ' + '_async_handle_command :: %s', cmd)
 


### PR DESCRIPTION
This helps to use one script only instead of three scripts for each cover.
It's passing to the script two variables: 
1. the name of the cover as `source`
2. the `command`  ( "open", "close", "stop" )

You still have to declare the script for each different action:

```
cover:
  - platform: cover_rf_time_based
    devices:
      my_room_cover_time_based:
        name: My Room Cover
        travelling_time_up: 36
        travelling_time_down: 34
        close_script_entity_id: script.rf_myroom_cover
        stop_script_entity_id: script.rf_myroom_cover
        open_script_entity_id: script.rf_myroom_cover
       
```

and assuming that the unique_id (e.g. `my_room_cover_time_based` ) is the same as the name of the device in the remote, 
you can use only one script

```
alias: rf_myroom_cover
sequence:
  - service: remote.send_command
    data:
      command: "{{command}}"
      device: "{{source}}"
    target:
      entity_id: remote.remote_remote
mode: single
```